### PR TITLE
Add landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,65 +1,190 @@
-import Image from "next/image";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { APP_CONFIG } from "@/config/app";
 
-export default function Home() {
+export const metadata: Metadata = {
+  title: `${APP_CONFIG.name} — ${APP_CONFIG.tagline}`,
+  description:
+    "Find jobs matched to your background, tailor every application in seconds, and track your entire search in one place.",
+};
+
+const FEATURES = [
+  {
+    number: "01",
+    title: "Jobs matched to you",
+    description:
+      "We scan job boards daily and score every listing against your background. Best-fit roles rise to the top — not just the most recently posted ones.",
+  },
+  {
+    number: "02",
+    title: "Applications tailored in seconds",
+    description:
+      "Pick a role, click Tailor, and get a resume rewritten to mirror the job description. Edit it to add your own voice, then export straight to PDF.",
+  },
+  {
+    number: "03",
+    title: "Track every application",
+    description:
+      "A simple pipeline keeps every application in view from first interest through to offer. No spreadsheets, no lost follow-ups.",
+  },
+] as const;
+
+export default function LandingPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
+    <div className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
+
+      {/* ── Nav ─────────────────────────────────────────────────────── */}
+      <header className="border-b border-[var(--border)] bg-[var(--bg-card)]">
+        <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-6">
+          <div className="flex items-center gap-2.5">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--accent)] text-[var(--accent-fg)] text-xs font-bold shadow-sm">
+              S
+            </span>
+            <span className="text-sm font-semibold tracking-tight">
+              {APP_CONFIG.name}
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              href="/sign-in"
+              className="text-sm font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
+            >
+              Sign in
+            </Link>
+            <Link
+              href="/sign-up"
+              className="inline-flex h-8 items-center rounded-lg bg-[var(--accent)] px-4 text-sm font-semibold text-[var(--accent-fg)] transition-opacity hover:opacity-90"
+            >
+              Get started
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* ── Hero ────────────────────────────────────────────────────── */}
+      <section className="relative overflow-hidden border-b border-[var(--border)]">
+        {/* Decorative background letter */}
+        <span
+          className="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 select-none text-[22rem] font-black leading-none text-[var(--text)] opacity-[0.03] sm:text-[28rem]"
+          aria-hidden="true"
+        >
+          S
+        </span>
+
+        {/* Subtle radial gradient for depth */}
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% -10%, var(--accent) 0%, transparent 70%)",
+            opacity: 0.06,
+          }}
+          aria-hidden="true"
         />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+
+        <div className="relative z-10 mx-auto max-w-4xl px-6 py-28 text-center sm:py-36">
+          <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--bg-card)] px-3.5 py-1.5 text-xs font-medium text-[var(--text-muted)]">
+            <span className="h-1.5 w-1.5 rounded-full bg-[var(--accent)]" aria-hidden="true" />
+            AI-powered job search
+          </div>
+
+          <h1 className="text-5xl font-bold leading-[1.05] tracking-tight text-[var(--text)] sm:text-7xl">
+            Get on the
+            <br />
+            <span className="text-[var(--accent)]">shortlist.</span>
           </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+
+          <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-[var(--text-muted)] sm:text-xl">
+            Find roles that actually fit your background, tailor every application
+            in seconds, and track your entire search — all in one place.
+          </p>
+
+          <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+            <Link
+              href="/sign-up"
+              className="inline-flex h-11 items-center rounded-xl bg-[var(--accent)] px-7 text-sm font-semibold text-[var(--accent-fg)] shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
             >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
+              Get started free
+            </Link>
+            <Link
+              href="/sign-in"
+              className="inline-flex h-11 items-center rounded-xl border border-[var(--border)] bg-[var(--bg-card)] px-7 text-sm font-medium text-[var(--text)] transition-colors hover:bg-[var(--bg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
             >
-              Learning
-            </a>{" "}
-            center.
+              Sign in
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Features ────────────────────────────────────────────────── */}
+      <section className="mx-auto max-w-5xl px-6 py-20 sm:py-28">
+        <p className="mb-12 text-center text-xs font-semibold uppercase tracking-widest text-[var(--text-muted)]">
+          How it works
+        </p>
+        <div className="grid gap-6 sm:grid-cols-3">
+          {FEATURES.map(({ number, title, description }) => (
+            <article
+              key={number}
+              className="rounded-2xl border border-[var(--border)] bg-[var(--bg-card)] p-7"
+              style={{ boxShadow: "var(--shadow-card)" }}
+            >
+              <span className="mb-5 block font-mono text-3xl font-black text-[var(--accent)] opacity-70">
+                {number}
+              </span>
+              <h3 className="mb-2.5 text-base font-semibold text-[var(--text)]">
+                {title}
+              </h3>
+              <p className="text-sm leading-relaxed text-[var(--text-muted)]">
+                {description}
+              </p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {/* ── CTA strip ───────────────────────────────────────────────── */}
+      <section className="border-y border-[var(--border)] bg-[var(--bg-subtle)]">
+        <div className="mx-auto max-w-5xl px-6 py-16 text-center">
+          <h2 className="text-2xl font-bold tracking-tight text-[var(--text)] sm:text-3xl">
+            Ready to find your next role?
+          </h2>
+          <p className="mt-3 text-sm text-[var(--text-muted)]">
+            Set up your profile in under two minutes.
+          </p>
+          <Link
+            href="/sign-up"
+            className="mt-7 inline-flex h-11 items-center rounded-xl bg-[var(--accent)] px-8 text-sm font-semibold text-[var(--accent-fg)] shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+          >
+            Get started free
+          </Link>
+        </div>
+      </section>
+
+      {/* ── Footer ──────────────────────────────────────────────────── */}
+      <footer className="mx-auto max-w-5xl px-6 py-8">
+        <div className="flex flex-col items-center justify-between gap-3 sm:flex-row">
+          <div className="flex items-center gap-2">
+            <span className="flex h-5 w-5 items-center justify-center rounded bg-[var(--accent)] text-[var(--accent-fg)] text-[10px] font-bold">
+              S
+            </span>
+            <span className="text-xs font-medium text-[var(--text-muted)]">
+              {APP_CONFIG.name}
+            </span>
+          </div>
+          <p className="text-xs text-[var(--text-muted)]">
+            Built by{" "}
+            <a
+              href="https://johnmoorman.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--text)] transition-colors hover:text-[var(--accent)]"
+            >
+              John Moorman
+            </a>
           </p>
         </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
-      </main>
+      </footer>
+
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the default Next.js scaffold at `/` with a proper landing page.

- **Nav** — logo + Sign in + Get started CTA
- **Hero** — "Get on the shortlist." headline, tagline, dual CTA buttons; oversized decorative S + subtle radial accent gradient for depth
- **How it works** — three numbered feature cards (01 Find, 02 Tailor, 03 Track)
- **CTA strip** — bottom call-to-action with sign-up link
- **Footer** — app name + link to johnmoorman.com

Fully respects the app's CSS custom properties — light and dark mode work automatically.

## Testing checklist

- [ ] Visit `/` — landing page renders (not the Next.js scaffold)
- [ ] Light mode: all text, cards, and borders use correct design tokens
- [ ] Dark mode: switch theme — page reacts correctly, no hardcoded colours
- [ ] "Get started" and "Get started free" both link to `/sign-up`
- [ ] "Sign in" links to `/sign-in`
- [ ] Footer "John Moorman" link opens `https://johnmoorman.com` in a new tab
- [ ] Page is responsive — hero text and feature cards stack correctly on mobile
- [ ] Authenticated users visiting `/` see the landing page (no redirect — middleware only redirects from `/dashboard` and below)