### PR TITLE
Allow production Clerk domain in Content Security Policy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,12 +4,12 @@ import bundleAnalyzer from "@next/bundle-analyzer";
 // Content-Security-Policy — unsafe-eval required by @uiw/react-md-editor internals
 const csp = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://*.clerk.accounts.dev",
+  "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://*.clerk.accounts.dev https://clerk.shortlist.johnmoorman.com",
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: https://logo.clearbit.com https://img.clerk.com",
   "font-src 'self'",
-  "connect-src 'self' https://api.clerk.com https://*.clerk.accounts.dev https://openrouter.ai",
-  "frame-src 'self' blob: https://challenges.cloudflare.com https://*.clerk.accounts.dev",
+  "connect-src 'self' https://api.clerk.com https://*.clerk.accounts.dev https://clerk.shortlist.johnmoorman.com https://openrouter.ai",
+  "frame-src 'self' blob: https://challenges.cloudflare.com https://*.clerk.accounts.dev https://clerk.shortlist.johnmoorman.com",
   "worker-src 'self' blob:",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
## Summary

Clerk's production Frontend API runs on `clerk.shortlist.johnmoorman.com` instead of `*.clerk.accounts.dev` (development). The CSP was blocking the production Clerk JS bundle, resulting in a blank sign-in page.

Adds `clerk.shortlist.johnmoorman.com` to `script-src`, `connect-src`, and `frame-src` directives. Dev entries (`*.clerk.accounts.dev`) kept for local dev and CI.

## Test plan

- [ ] Production sign-in page renders at shortlist.johnmoorman.com/sign-in
- [ ] Local dev sign-in still works with dev Clerk keys