### PR TITLE
Auto-remap user accounts by email on production Clerk signup

### DIFF
--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -15,6 +15,22 @@ export async function POST(req: NextRequest) {
           (e) => e.id === evt.data.primary_email_address_id,
         )?.email_address ?? null;
 
+      // Check if a user with this email exists from a previous Clerk instance
+      // (e.g., dev → prod migration). If so, remap their account to the new ID
+      // so all their profiles, jobs, and applications transfer automatically.
+      if (email) {
+        const existing = await prisma.user.findFirst({
+          where: { email, id: { not: id } },
+        });
+        if (existing) {
+          await prisma.user.update({
+            where: { id: existing.id },
+            data: { id, email },
+          });
+          return new Response("OK", { status: 200 });
+        }
+      }
+
       await prisma.user.upsert({
         where: { id },
         create: { id, email },


### PR DESCRIPTION
## Summary

When a user signs up on the production Clerk instance, the webhook now checks if a user with the same email already exists in the DB (from the dev Clerk instance). If found, it remaps the existing user's ID to the new production Clerk ID — automatically transferring all their profiles, jobs, applications, and tailored resumes.

This eliminates the need for manual SQL ID swaps during the dev → prod Clerk migration.

## How it works

1. `user.created` webhook fires with new production Clerk ID + email
2. Query: is there an existing user with this email but a different ID?
3. If yes: update the existing user's ID to the new one (all FK relations follow)
4. If no: create a fresh user as normal

## Test plan

- [x] Sign up on production with an email that exists in the dev DB → data transfers
- [x] Sign up with a brand new email → fresh account created
- [x] Webhook delivery shows 200 in Clerk dashboard